### PR TITLE
Fix switching between 'Parameters' and 'Settings'

### DIFF
--- a/app.py
+++ b/app.py
@@ -294,15 +294,6 @@ class SpinLabMeasurement(Procedure):
     
     def shutdown(self):
         pass
-
-    def change_input_type(self): 
-        if SpinLabMeasurement.layout_type == True:
-            SpinLabMeasurement.layout_type = False 
-            MainWindow.change_input_type(self,False)
-        else: 
-            SpinLabMeasurement.layout_type = True 
-            MainWindow.change_input_type(self,True)
-        print(SpinLabMeasurement.layout_type)
     
     # def get_estimates(self, sequence_length=None, sequence=None):
     #                 self.iterations = self.points
@@ -366,8 +357,11 @@ class MainWindow(ManagedDockWindow):
                 continue
             input_widget.setValue("None")
     
-    def change_input_type(self, value): 
-        self.inputs.layout_type.setCheckState(value)
+    def change_input_type(self): 
+        if self.inputs.layout_type.value():
+            self.inputs.layout_type.setValue(False)
+        else:
+            self.inputs.layout_type.setValue(True)
     
     def set_sample_name(self, value):
         self.inputs.sample_name.setValue(value)

--- a/pymeasure/display/windows/managed_window.py
+++ b/pymeasure/display/windows/managed_window.py
@@ -174,8 +174,6 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         self.settings_button = QtWidgets.QPushButton('Settings', self)
         self.parameters_button = QtWidgets.QPushButton('Parameters', self)
         self.abort_button.setEnabled(False)
-        self.settings_button.setEnabled(False)
-        self.parameters_button.setEnabled(True)
         self.abort_button.clicked.connect(self.abort)
         self.settings_button.clicked.connect(self.settings_function)
         self.parameters_button.clicked.connect(self.parameters_function)
@@ -208,6 +206,15 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             hide_groups=self.hide_groups,
             inputs_in_scrollarea=self.inputs_in_scrollarea,
         )
+        
+        if self.inputs.layout_type.value():
+            self.parameters_button.setEnabled(False)
+            self.settings_button.setEnabled(True)
+        else:
+            self.parameters_button.setEnabled(True)
+            self.settings_button.setEnabled(False)
+        
+        
         if self.enable_file_input:
             self.file_input = FileInputWidget(parent=self)
 
@@ -521,6 +528,9 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
 
     def refresh(self):
         raise NotImplementedError("Refresh method must be overwritten by the child class.")
+    
+    def change_input_type(self):
+        raise NotImplementedError("Change input type method must be overwritten by the child class.")
 
     def _queue(self, checked):
         """ This method is a wrapper for the `self.queue` method to be connected
@@ -609,12 +619,12 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
     def settings_function(self): 
         self.settings_button.setEnabled(False)
         self.parameters_button.setEnabled(True)
-        self.procedure_class.change_input_type(self)
+        self.change_input_type()
 
     def parameters_function(self):
         self.settings_button.setEnabled(True)
         self.parameters_button.setEnabled(False)
-        self.procedure_class.change_input_type(self)
+        self.change_input_type()
 
 
     def resume(self):


### PR DESCRIPTION
After opening the program for the first time, it was necessary to press the corresponding button twice to switch from the "parameters" tab to the "settings" tab. Changing the default value of the "layout_type" parameter caused erroneous behavior when switching between tabs.

Moved all the tab-switching functionality to the "MainWindow" class. The initial state of the buttons is now determined by the value of the "layout_type" parameter.