### PR TITLE
add data normalization

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ from modules.cims_mode import CIMSMode
 from modules.calibration_mode import FieldCalibrationMode
 from logic.find_instrument import FindInstrument
 from logic.save_parameters import SaveParameters
+from logic.normalize import Normalize
 
 from datetime import datetime
 from datetime import timedelta
@@ -195,7 +196,8 @@ class SpinLabMeasurement(Procedure):
     number_of_points = IntegerParameter("Number of points", default = 0, group_by={"mode": lambda v: v == "default"})
 
     DEBUG = 1
-    DATA_COLUMNS = ['Voltage (V)', 'Current (A)', 'Resistance (ohm)', 'Field (Oe)', 'Frequency (Hz)', 'X (V)', 'Y (V)', 'Phase', 'Polar angle (deg)', 'Azimuthal angle (deg)','Applied Voltage (V)' ]
+    DATA_COLUMNS = ['Voltage (V)', 'Norm Voltage (V)' , 'Current (A)', 'Resistance (ohm)', 'Field (Oe)', 'Frequency (Hz)', 'X (V)', 'Norm X (V)', 'Y (V)', 'Phase', 'Polar angle (deg)', 'Azimuthal angle (deg)','Applied Voltage (V)' ]
+    normalize = Normalize(to_normalize=["Voltage (V)", "X (V)"])
     path_file = SaveFilePath()
     
     def refresh_parameters(self):
@@ -252,7 +254,8 @@ class SpinLabMeasurement(Procedure):
         self.points = self.selected_mode.generate_points()
         self.selected_mode.initializing()
 
-        window.inputs.number_of_points.setValue(len(self.points))        
+        window.inputs.number_of_points.setValue(len(self.points))
+        self.normalize._result_object = window.manager.running_experiment().results   
 
 #################################### PROCEDURE##############################################
     def execute(self):
@@ -270,6 +273,8 @@ class SpinLabMeasurement(Procedure):
             start_time = time()
             
             self.result = self.selected_mode.operating(point)
+            
+            self.result = self.normalize(self.result)
             
             self.emit('results', self.result)
             self.emit('progress', 100 * self.counter / len(self.points))

--- a/logic/normalize.py
+++ b/logic/normalize.py
@@ -1,5 +1,6 @@
 import numpy as np
 from threading import Lock
+from pymeasure.experiment.results import Results
 
 
 class Normalize:
@@ -12,7 +13,7 @@ class Normalize:
         for arg in self.to_normalize:
             self._args[arg] = [None, None]
 
-        self._result_object = result_object
+        self._result_object: Results = result_object
         self._lock = Lock()
 
     def __call__(self, results: dict):
@@ -39,10 +40,10 @@ class Normalize:
 
                     with open(self._result_object.data_filename, "w") as f:
                         f.write(self._result_object.header())
-                        f.write(self._result_object.metadata())
                         f.write(self._result_object.labels())
                         for _, row in data.iterrows():
-                            f.write(self._result_object.format(row.to_dict()) + "\n")
+                            f.write(self._result_object.format(row.to_dict()) + self._result_object.LINE_BREAK)
+                    self._result_object.store_metadata()
 
             with self._lock:
                 min_val, max_val = self._args[arg]

--- a/logic/normalize.py
+++ b/logic/normalize.py
@@ -1,0 +1,64 @@
+import numpy as np
+from threading import Lock
+
+
+class Normalize:
+    def __init__(self, to_normalize: list = None, result_object=None):
+        if to_normalize is None:
+            to_normalize = []
+        self.to_normalize = to_normalize
+
+        self._args = {}
+        for arg in self.to_normalize:
+            self._args[arg] = [None, None]
+
+        self._result_object = result_object
+        self._lock = Lock()
+
+    def __call__(self, results: dict):
+        if self._result_object is None:
+            raise Exception("Normalize: Result object not set!")
+
+        for arg in self.to_normalize:
+            if arg in results:
+                with self._lock:
+                    if self._args[arg][0] is None:
+                        self._args[arg][0] = results[arg]
+                        self._args[arg][1] = results[arg]
+                    else:
+                        self._args[arg][0] = min(self._args[arg][0], results[arg])
+                        self._args[arg][1] = max(self._args[arg][1], results[arg])
+
+                with self._lock:
+                    data = self._result_object.data
+                    min_val, max_val = self._args[arg]
+                    if max_val - min_val == 0:
+                        data[f"Norm {arg}"] = 0.0
+                    else:
+                        data[f"Norm {arg}"] = (data[arg].astype(float) - min_val) / (max_val - min_val)
+
+                    with open(self._result_object.data_filename, "w") as f:
+                        f.write(self._result_object.header())
+                        f.write(self._result_object.metadata())
+                        f.write(self._result_object.labels())
+                        for _, row in data.iterrows():
+                            f.write(self._result_object.format(row.to_dict()) + "\n")
+
+            with self._lock:
+                min_val, max_val = self._args[arg]
+                if max_val - min_val == 0:
+                    results[f"Norm {arg}"] = 0.0
+                else:
+                    results[f"Norm {arg}"] = (results[arg] - min_val) / (max_val - min_val)
+
+        return results
+
+
+if __name__ == "__main__":
+    norm = Normalize(["a", "b"])
+    results = {"a": 1, "b": 2}
+    print(norm(results))
+    results = {"a": 2, "b": 1}
+    print(norm(results))
+    results = {"a": 1, "b": 1.5}
+    print(norm(results))


### PR DESCRIPTION
## Overview
The Normalize class is designed to apply min-max normalization to specified fields within a dataset. This normalization scales the values of these fields to a range of [0,1], based on the minimum and maximum values encountered during data processing.

### Initialization
The class constructor takes two arguments:

*to_normalize*: A list of *DATA_COLUMNS* elements that will be normalized. 
*result_object*: An object that represents the running experiment's results (*Results* class), including the dataset to be normalized and methods for managing the file output.

### Important Notes:
- Columns for the normalized data must be added to the *DATA_COLUMNS* variable with the correct name!

  For example, to enable normalization of the 'Voltage (V)' column:

    - Add the string "Voltage (V)" to the *to_normalize* attribute of the *Normalize* class.
    - Add the string "Norm Voltage (V)" to the *DATA_COLUMNS* variable.

 - In the current version, the prefix for all normalized data columns must be "Norm "