### PR TITLE
Add automatic sequence load after generation

### DIFF
--- a/modules/generator_widget_automatic_station.py
+++ b/modules/generator_widget_automatic_station.py
@@ -23,7 +23,7 @@ class AutomaticStationGenerator(QtWidgets.QWidget):
         self.icon_path = "modules\icons\AutomaticStationGenerator.ico"
         self.address_list = ["None"]
         self.address = "None"
-        self.inputs = None
+        self.sequencer = None
         self.get_available_addresses()
         #self.make_connection_with_devices()
 
@@ -127,7 +127,6 @@ class AutomaticStationGenerator(QtWidgets.QWidget):
         self.read_for_go_button_button.clicked.connect(self.read_for_go_button)
 
         self.sample_in_plane_checkbox=QtWidgets.QCheckBox("Sample in plane",self)
-        self.sample_in_plane_checkbox.toggled.connect(lambda state: self.inputs.sample_in_plane.setValue(state))
         self.connect_with_sample(False)
         #self.sample_in_plane_checkbox.stateChanged()
 
@@ -297,6 +296,9 @@ class AutomaticStationGenerator(QtWidgets.QWidget):
 
         with open('./example_sequence','w') as f:
             f.write(seq_vector)
+            
+        if self.sequencer is not None:
+            self.sequencer.load_sequence(filename='./example_sequence')
 
         #data migration
         with open('./logic/parameters.json', 'r+') as file:

--- a/pymeasure/display/windows/managed_dock_window.py
+++ b/pymeasure/display/windows/managed_dock_window.py
@@ -95,7 +95,8 @@ class ManagedDockWindow(ManagedWindowBase):
         self.browser_widget.browser.measured_quantities.update(measure_quantities)
 
         try:
-            self.devices_widget.automatic_station_generator.inputs = self.inputs
+            self.devices_widget.automatic_station_generator.sample_in_plane_checkbox.toggled.connect(lambda state: self.inputs.sample_in_plane.setValue(state))
+            self.devices_widget.automatic_station_generator.sequencer = self.sequencer
         except AttributeError:
             pass
 


### PR DESCRIPTION
When the "Generate Sequence" button in the automatic station widget is pressed, the sequence is automatically loaded from the generated file. This is the simplest solution. The only disadvantage is that it overwrites anything that was previously in the sequencer.