### PR TITLE
implement always sweep field in fmr mode and resistance mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -288,12 +288,11 @@ class SpinLabMeasurement(Procedure):
             start_time = time()
 
             self.result = self.selected_mode.operating(point)
+            self.counter = self.counter + 1
 
             self.emit("results", self.result)
             self.emit("progress", 100 * self.counter / len(self.points))
             self.emit("current_point", point)
-
-            self.counter = self.counter + 1
 
             window.inputs.point_meas_duration.setValue(time() - start_time)
 

--- a/logic/sweep_field_to_value.py
+++ b/logic/sweep_field_to_value.py
@@ -32,12 +32,12 @@ def sweep_field_to_value(start_field: float, end_field: float, field_step: float
 
     # set print options to avoid printing large arrays to console
     np.set_printoptions(threshold=10)
-    print(f"Sweeping field from: {start_field} to: {end_field} with {len(field_values)} steps: {field_values}")
+    print(f"Sweeping field from: {start_field:.2f} to: {end_field:.2f} with {len(field_values)} steps: {field_values}")
     # reset print options to default
     np.set_printoptions(threshold=1000)
 
     if emit_info_callback:
-        emit_info_callback("info", f"Sweeping field from: {start_field} to: {end_field} [Oe]")
+        emit_info_callback("info", f"Sweeping field from: {start_field:.2f} to: {end_field:.2f} [Oe]")
 
     for field in field_values:
         

--- a/logic/sweep_field_to_zero.py
+++ b/logic/sweep_field_to_zero.py
@@ -34,12 +34,12 @@ def sweep_field_to_zero(start_field: float, field_constant: float, field_step: f
 
     # set print options to avoid printing large arrays to console
     np.set_printoptions(threshold=10)
-    print(f"Sweeping field from: {start_field} to: 0 with {len(field_values)} steps: {field_values}")
+    print(f"Sweeping field from: {start_field:.2f} to: 0 with {len(field_values)} steps: {field_values}")
     # reset print options to default
     np.set_printoptions(threshold=1000)
 
     if emit_info_callback:
-        emit_info_callback("info", f"Sweeping field from: {start_field} to: 0 [Oe]")
+        emit_info_callback("info", f"Sweeping field from: {start_field:.2f} to: 0 [Oe]")
 
     for field in field_values:
 

--- a/modules/fmr_mode.py
+++ b/modules/fmr_mode.py
@@ -197,6 +197,8 @@ class FMRMode(MeasurementMode):
             self.lockin_obj.phase = 0
         else:
             self.lockin_obj.phase = 180
+            
+        self.prev_point = initial_field
 
         sleep(1)
 
@@ -205,9 +207,11 @@ class FMRMode(MeasurementMode):
 
         match self.p.mode_fmr:
             case "V-FMR":
-                self.field_obj.set_field(point)
+                sweep_field_to_value(self.prev_point, point, self.p.field_step, self.field_obj, emit_info_callback=self.p.emit)
             case "ST-FMR":
                 self.generator_obj.setFreq(point)
+                
+        self.prev_point = point
 
         sleep(self.p.delay_field)
 

--- a/modules/resistance_mode.py
+++ b/modules/resistance_mode.py
@@ -135,12 +135,13 @@ class ResistanceMode(MeasurementMode):
         # Field initialization
         self.field_obj.field_constant = self.p.field_constant
         if self.p.set_rotationstation:
-            sweep_field_to_value(0, self.p.constant_field_value, self.p.field_step, self.field_obj)
             self.tmp_field = self.p.constant_field_value
         else:
-            sweep_field_to_value(0, self.point_list[0], self.p.field_step, self.field_obj)
             self.tmp_field = self.point_list[0]
-
+            
+        sweep_field_to_value(0, self.tmp_field, self.p.field_step, self.field_obj, emit_info_callback=self.p.emit)
+        self.prev_point = self.tmp_field
+        
         # MotionDriver
         if self.p.set_automaticstation:
             if self.p.address_automaticstation == "None":
@@ -164,7 +165,8 @@ class ResistanceMode(MeasurementMode):
 
         else:
             pass
-        self.field_obj.set_field(point)
+        sweep_field_to_value(self.prev_point, point, self.p.field_step, self.field_obj, emit_info_callback=self.p.emit)
+        self.prev_point = point
         sleep(self.p.delay_field)
 
         # measure field
@@ -226,7 +228,7 @@ class ResistanceMode(MeasurementMode):
 
     def idle(self):
         self.sourcemeter_obj.shutdown()
-        sweep_field_to_zero(self.tmp_field, self.p.field_constant, self.p.field_step, self.field_obj)
+        sweep_field_to_zero(self.tmp_field, self.p.field_constant, self.p.field_step, self.field_obj, emit_info_callback=self.p.emit)
         if (self.p.set_rotationstation or self.p.rotation_axis == "None") and self.p.return_the_rotationstation:
             self.rotationstation_obj.goToZero()
 


### PR DESCRIPTION
Add field sweeping inside measurement modes (fmr, resistance)  operating function.
Previously, the field was set within the operating function regardless of the difference from the previous value.